### PR TITLE
Reuse _get_service_metadata_from_registry and add_p_service_in_registry

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -725,7 +725,6 @@ def add_sdk_options(parser):
     p.add_argument("language", choices=supported_languages,
                    help="choose target language for the generated client library from {}".format(supported_languages),
                    metavar="LANGUAGE")
-    p.add_argument("org_id", help="Id of the target service organization in the SingularityNET Registry", metavar="ORGANIZATION_ID")
-    p.add_argument("service_id", help="Id of the target service in the SingularityNET Registry", metavar="SERVICE_ID")
+    add_p_service_in_registry(p)
     p.add_argument("protodir", nargs="?", help="Directory where to output the generated client libraries", metavar="PROTODIR")
     add_eth_call_arguments(p)

--- a/snet_cli/sdk_command.py
+++ b/snet_cli/sdk_command.py
@@ -1,4 +1,4 @@
-from snet_cli.commands import BlockchainCommand
+from snet_cli.mpe_service_command import MPEServiceCommand
 import os 
 from pathlib import Path, PurePath
 from tempfile import TemporaryDirectory
@@ -7,7 +7,7 @@ from snet_cli.utils import type_converter, bytes32_to_str, compile_proto
 from snet_cli.utils_ipfs import bytesuri_to_hash, get_from_ipfs_and_checkhash, safe_extract_proto_from_ipfs
 from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json
 
-class SDKCommand(BlockchainCommand):
+class SDKCommand(MPEServiceCommand):
     def generate_client_library(self):
         cur_dir_path = PurePath(os.path.dirname(os.path.realpath(__file__)))
 
@@ -24,16 +24,6 @@ class SDKCommand(BlockchainCommand):
             if not os.path.isdir(client_libraries_base_dir_path):
                 self._error("directory {} does not exist. Please make sure that the specified path exists".format(client_libraries_base_dir_path))
 
-        # Check that service exists
-        (found, org_service_list) = self.call_contract_command("Registry", "listServicesForOrganization", [type_converter("bytes32")(self.args.org_id)])
-        if not found:
-            self._error("organization {} does not exist".format(self.args.org_id))
-
-        org_service_list = list(map(bytes32_to_str, org_service_list))
-
-        if self.args.service_id not in org_service_list:
-            self._error("service {} does not exist in organization {}".format(self.args.service_id, self.args.org_id))
-
         # Create service client libraries path
         library_language = self.args.language
         library_org_id = self.args.org_id
@@ -41,11 +31,7 @@ class SDKCommand(BlockchainCommand):
 
         library_dir_path = client_libraries_base_dir_path.joinpath(library_language, library_org_id, library_service_id)
 
-        # Download and extract proto files
-        ipfs_metadata_hash = bytesuri_to_hash(self.call_contract_command("Registry", "getServiceRegistrationById", [type_converter("bytes32")(self.args.org_id), type_converter("bytes32")(self.args.service_id)])[2])
-        metadata = get_from_ipfs_and_checkhash(self._get_ipfs_client(), ipfs_metadata_hash)
-        metadata = metadata.decode("utf-8")
-        metadata = mpe_service_metadata_from_json(metadata)
+        metadata = self._get_service_metadata_from_registry()
         model_ipfs_hash = metadata["model_ipfs_hash"]
 
         with TemporaryDirectory() as temp_dir: 


### PR DESCRIPTION
This PR does following
* reuse MPEServiceCommand._get_service_metadata_from_registry
* reuse add_p_service_in_registry (in order to have the same messages for "service_id" and "org_id" everythere)
