### PR TITLE
Compile js tests2

### DIFF
--- a/snet_cli/arguments.py
+++ b/snet_cli/arguments.py
@@ -1092,6 +1092,7 @@ def add_sdk_options(parser):
     add_p_service_in_registry(p)
     p.add_argument("protodir",
                    nargs="?",
+                   default="client_libraries",
                    help="Directory where to output the generated client libraries",
                    metavar="PROTO_DIR")
     add_eth_call_arguments(p)

--- a/snet_cli/sdk_command.py
+++ b/snet_cli/sdk_command.py
@@ -9,20 +9,14 @@ from snet_cli.mpe_service_metadata import mpe_service_metadata_from_json
 
 class SDKCommand(MPEServiceCommand):
     def generate_client_library(self):
-        cur_dir_path = PurePath(os.getcwd())
 
-        if not self.args.protodir:
-            client_libraries_base_dir_path = cur_dir_path.joinpath("client_libraries")
-            if not os.path.exists(client_libraries_base_dir_path):
-                os.makedirs(client_libraries_base_dir_path)
+        if os.path.isabs(self.args.protodir):
+            client_libraries_base_dir_path = PurePath(self.args.protodir)
         else:
-            if os.path.isabs(self.args.protodir):
-                client_libraries_base_dir_path = PurePath(self.args.protodir)
-            else: 
-                client_libraries_base_dir_path = cur_dir_path.joinpath(self.args.protodir)
+            cur_dir_path = PurePath(os.getcwd())
+            client_libraries_base_dir_path = cur_dir_path.joinpath(self.args.protodir)
 
-            if not os.path.isdir(client_libraries_base_dir_path):
-                self._error("directory {} does not exist. Please make sure that the specified path exists".format(client_libraries_base_dir_path))
+        os.makedirs(client_libraries_base_dir_path, exist_ok = True)
 
         # Create service client libraries path
         library_language = self.args.language

--- a/test/functional_tests/script15_sdk_generate_client_library.sh
+++ b/test/functional_tests/script15_sdk_generate_client_library.sh
@@ -1,0 +1,19 @@
+
+# simple case of one group
+snet service metadata-init ./service_spec1/ ExampleService 0x52653A9091b5d5021bed06c5118D24b23620c529  --fixed-price 0.0001 --endpoints 8.8.8.8:2020
+snet organization create testo --org-id testo -y -q
+snet service publish testo tests -y -q
+
+snet sdk generate-client-library python testo tests
+test -f client_libraries/testo/tests/python/ExampleService_pb2_grpc.py
+
+snet sdk generate-client-library nodejs testo tests
+test -f client_libraries/testo/tests/nodejs/ExampleService_grpc_pb.js
+
+# test relative path (and using already installed compiler)
+snet sdk generate-client-library nodejs testo tests snet_output
+test -f snet_output/testo/tests/nodejs/ExampleService_grpc_pb.js
+
+# test absolute path
+snet sdk generate-client-library nodejs testo tests /tmp/snet_output
+test -f /tmp/snet_output/testo/tests/nodejs/ExampleService_grpc_pb.js


### PR DESCRIPTION
Hello @vforvalerio87.

I propose to add two commits in your PR (https://github.com/singnet/snet-cli/pull/255). 
1. Tests for ```snet sdk generate-client-library python/nodejs```
2. Minor change with moving default ```client_libraries```  for ```snet sdk``` directory to arguments.py, and make all directories...

Fill free to reject this proposition or reuse only parts of it.. It is only proposition... 